### PR TITLE
W-22185076: Add internal visibility keyword and improve scope naming

### DIFF
--- a/DataWeave.YAML-tmLanguage
+++ b/DataWeave.YAML-tmLanguage
@@ -66,8 +66,8 @@ repository:
         match: (\-|\+|\*|\/)
       - name: keyword.operator.implement.dw
         match: \?\?\?
-      - name: storage.modifier.directive.dw
-        match: (?<![[:alnum:]])(?:private)(?![[:alnum:]_])
+      - name: storage.modifier.dw
+        match: (?<![[:alnum:]])(?:private|internal)(?![[:alnum:]_])
 
   directive:
     patterns:

--- a/DataWeave.tmLanguage
+++ b/DataWeave.tmLanguage
@@ -204,9 +204,9 @@
           </dict>
           <dict>
             <key>name</key>
-            <string>storage.modifier.directive.dw</string>
+            <string>storage.modifier.dw</string>
             <key>match</key>
-            <string>(?&lt;![[:alnum:]])(?:private)(?![[:alnum:]_])</string>
+            <string>(?&lt;![[:alnum:]])(?:private|internal)(?![[:alnum:]_])</string>
           </dict>
         </array>
       </dict>

--- a/tests/cases/internal_scope_directives.dwl
+++ b/tests/cases/internal_scope_directives.dwl
@@ -1,0 +1,16 @@
+%dw 2.0
+output application/xml
+
+internal ns ns0 = "http://myns"
+
+internal type MY_STRING = String
+
+internal var a = "internal"
+
+internal fun hi(t: MY_STRING) = t
+---
+root: {
+  a: a,
+  hi: hi("hi")
+  ns0#h: 123,
+}

--- a/tests/cases/internal_scope_directives.dwl.snap
+++ b/tests/cases/internal_scope_directives.dwl.snap
@@ -1,0 +1,99 @@
+>%dw 2.0
+#^^^ source.data-weave meta.directive.version.dw keyword.directive.version.dw
+#   ^ source.data-weave meta.directive.version.dw
+#    ^^^ source.data-weave meta.directive.version.dw constant.numeric.version.dw
+>output application/xml
+#^^^^^^ source.data-weave storage.type.dw
+#      ^ source.data-weave
+#       ^^^^^^^^^^^ source.data-weave entity.name.variable.dw
+#                  ^ source.data-weave keyword.operator.arithmetic.dw
+#                   ^^^ source.data-weave entity.name.variable.dw
+>
+>internal ns ns0 = "http://myns"
+#^^^^^^^^ source.data-weave storage.modifier.dw
+#        ^ source.data-weave
+#         ^^ source.data-weave storage.type.dw
+#           ^ source.data-weave
+#            ^^^ source.data-weave entity.name.variable.dw
+#               ^ source.data-weave
+#                ^ source.data-weave markup.underline.link
+#                 ^ source.data-weave
+#                  ^ source.data-weave string.quoted.double.dw punctuation.definition.string.begin.dw
+#                   ^^^^^^^^^^^ source.data-weave string.quoted.double.dw
+#                              ^ source.data-weave string.quoted.double.dw punctuation.definition.string.end.dw
+>
+>internal type MY_STRING = String
+#^^^^^^^^ source.data-weave storage.modifier.dw
+#        ^ source.data-weave
+#         ^^^^ source.data-weave storage.type.dw
+#             ^ source.data-weave
+#              ^^^^^^^^^ source.data-weave entity.name.variable.dw
+#                       ^ source.data-weave
+#                        ^ source.data-weave keyword.operator.assignment.dw
+#                         ^ source.data-weave
+#                          ^^^^^^ source.data-weave entity.name.variable.dw
+>
+>internal var a = "internal"
+#^^^^^^^^ source.data-weave storage.modifier.dw
+#        ^ source.data-weave
+#         ^^^ source.data-weave storage.type.dw
+#            ^ source.data-weave
+#             ^ source.data-weave entity.name.variable.dw
+#              ^ source.data-weave
+#               ^ source.data-weave keyword.operator.assignment.dw
+#                ^ source.data-weave
+#                 ^ source.data-weave string.quoted.double.dw punctuation.definition.string.begin.dw
+#                  ^^^^^^^^ source.data-weave string.quoted.double.dw
+#                          ^ source.data-weave string.quoted.double.dw punctuation.definition.string.end.dw
+>
+>internal fun hi(t: MY_STRING) = t
+#^^^^^^^^ source.data-weave storage.modifier.dw
+#        ^ source.data-weave
+#         ^^^ source.data-weave storage.type.dw
+#            ^ source.data-weave
+#             ^^ source.data-weave entity.name.variable.dw
+#               ^ source.data-weave
+#                ^ source.data-weave entity.name.variable.dw
+#                 ^ source.data-weave keyword.operator.declaration.dw
+#                  ^ source.data-weave
+#                   ^^^^^^^^^ source.data-weave entity.name.variable.dw
+#                            ^^ source.data-weave
+#                              ^ source.data-weave keyword.operator.assignment.dw
+#                               ^ source.data-weave
+#                                ^ source.data-weave entity.name.variable.dw
+>---
+#^^^ source.data-weave keyword.operator.body-marker.dw
+>root: {
+#^^^^ source.data-weave entity.name.variable.dw
+#    ^ source.data-weave keyword.operator.declaration.dw
+#     ^^^ source.data-weave
+>  a: a,
+#^^ source.data-weave
+#  ^ source.data-weave entity.name.variable.dw
+#   ^ source.data-weave keyword.operator.declaration.dw
+#    ^ source.data-weave
+#     ^ source.data-weave entity.name.variable.dw
+#      ^^ source.data-weave
+>  hi: hi("hi")
+#^^ source.data-weave
+#  ^^ source.data-weave entity.name.variable.dw
+#    ^ source.data-weave keyword.operator.declaration.dw
+#     ^ source.data-weave
+#      ^^ source.data-weave entity.name.variable.dw
+#        ^ source.data-weave
+#         ^ source.data-weave string.quoted.double.dw punctuation.definition.string.begin.dw
+#          ^^ source.data-weave string.quoted.double.dw
+#            ^ source.data-weave string.quoted.double.dw punctuation.definition.string.end.dw
+#             ^^ source.data-weave
+>  ns0#h: 123,
+#^^ source.data-weave
+#  ^^^ source.data-weave entity.name.variable.dw
+#     ^ source.data-weave
+#      ^ source.data-weave entity.name.variable.dw
+#       ^ source.data-weave keyword.operator.declaration.dw
+#        ^ source.data-weave
+#         ^^^ source.data-weave constant.numeric.dw
+#            ^^ source.data-weave
+>}
+#^^ source.data-weave
+>

--- a/tests/cases/private_scope_directives.dwl.snap
+++ b/tests/cases/private_scope_directives.dwl.snap
@@ -10,7 +10,7 @@
 #                   ^^^ source.data-weave entity.name.variable.dw
 >
 >private ns ns0 = "http://myns"
-#^^^^^^^ source.data-weave storage.modifier.directive.dw
+#^^^^^^^ source.data-weave storage.modifier.dw
 #       ^ source.data-weave
 #        ^^ source.data-weave storage.type.dw
 #          ^ source.data-weave
@@ -23,7 +23,7 @@
 #                             ^ source.data-weave string.quoted.double.dw punctuation.definition.string.end.dw
 >
 >private type MY_STRING = String
-#^^^^^^^ source.data-weave storage.modifier.directive.dw
+#^^^^^^^ source.data-weave storage.modifier.dw
 #       ^ source.data-weave
 #        ^^^^ source.data-weave storage.type.dw
 #            ^ source.data-weave
@@ -34,7 +34,7 @@
 #                         ^^^^^^ source.data-weave entity.name.variable.dw
 >
 >private var a = "private"
-#^^^^^^^ source.data-weave storage.modifier.directive.dw
+#^^^^^^^ source.data-weave storage.modifier.dw
 #       ^ source.data-weave
 #        ^^^ source.data-weave storage.type.dw
 #           ^ source.data-weave
@@ -47,7 +47,7 @@
 #                        ^ source.data-weave string.quoted.double.dw punctuation.definition.string.end.dw
 >
 >private fun hi(t: MY_STRING) = t
-#^^^^^^^ source.data-weave storage.modifier.directive.dw
+#^^^^^^^ source.data-weave storage.modifier.dw
 #       ^ source.data-weave
 #        ^^^ source.data-weave storage.type.dw
 #           ^ source.data-weave


### PR DESCRIPTION
  - Add support for 'internal' keyword alongside 'private'
  - Change scope from storage.modifier.directive.dw to storage.modifier.dw
  - More accurate semantic naming following industry standards (Java, TypeScript)
  - Add test case for internal keyword with ns, type, var, fun declarations
  - Update private test snapshots to reflect new scope name
  - All 33 tests passing